### PR TITLE
fix layout issue for avalanch

### DIFF
--- a/src/client/js/components/partials/swap/SwapWidget.jsx
+++ b/src/client/js/components/partials/swap/SwapWidget.jsx
@@ -104,11 +104,13 @@ export default class SwapOrderWidget extends Component {
   updateBoxHeight() {
     this.box.current.style.height = "";
     _.defer(function() {
+      console.log('## current offsetHeight ###', this.box.current.offsetHeight);
       this.box.current.style.height = `${this.box.current.offsetHeight}px`;
     }.bind(this))
   }
 
   triggerHeightResize(node, isAppearing) {
+    console.log('## offsetHeight ###', node.offsetHeight);
     this.box.current.style.height = `${node.offsetHeight}px`;
   }
 
@@ -129,7 +131,7 @@ export default class SwapOrderWidget extends Component {
     }, function() {
       _.delay(function() {
         // put back height after dist expand anim
-        this.updateBoxHeight();
+        // this.updateBoxHeight();
       }.bind(this), 301)
     }.bind(this));
   }

--- a/src/client/js/components/partials/swap/SwapWidget.jsx
+++ b/src/client/js/components/partials/swap/SwapWidget.jsx
@@ -131,7 +131,7 @@ export default class SwapOrderWidget extends Component {
     }, function() {
       _.delay(function() {
         // put back height after dist expand anim
-        // this.updateBoxHeight();
+        this.updateBoxHeight();
       }.bind(this), 301)
     }.bind(this));
   }


### PR DESCRIPTION
Hi, @chillvybz 
https://github.com/polkaswitch/polkaswitch-ui/issues/47

This error is not occurred on local when I test.  it works properly on local.
Strange, this issue occurred on server. https://app.polkaswitch.com (when select avalanch network only at the first time)
I guess, the problem is that the height of swap widget was set up with wrong by updateBoxHeight() after onSwapEstimateComplete()

I have one question for this. 
Do we necessarily need to call updateBoxHeight() after onSwapEstimateComplete()?

updateBoxHeight() {
    this.box.current.style.height = "";
    _.defer(function() {
      console.log('## current offsetHeight ###', this.box.current.offsetHeight);
      this.box.current.style.height = `${this.box.current.offsetHeight}px`;
    }.bind(this))
  }

onSwapEstimateComplete(fromAmount, toAmount, dist, availBalBN, approveStatus) {
    if (this.state.fromAmount === fromAmount &&
      this.state.availableBalance === availBalBN &&
      this.state.toAmount === toAmount) {
      return;
    }

    this.box.current.style.height = "";
    this.setState({
      fromAmount: fromAmount,
      toAmount: toAmount,
      swapDistribution: dist,
      availableBalance: availBalBN,
      approveStatus: approveStatus
    }, function() {
      _.delay(function() {
        // put back height after dist expand anim
        this.updateBoxHeight();
      }.bind(this), 301)
    }.bind(this));
  }

So I logged and I hope to test  after code merged.
I couldn't the issue on local. 

 