### PR TITLE
[Fix] Estimate bridges value overflow

### DIFF
--- a/src/client/js/components/partials/bridge/AdditionalInfoItem.jsx
+++ b/src/client/js/components/partials/bridge/AdditionalInfoItem.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-export default function AdditionalInfoItem(props) {
-  const info = props.info;
-
+const AdditionalInfoItem = ({ info }) => {
   return (
     <div className="additional-info">
       <div className="fee-wrapper">
@@ -15,4 +13,6 @@ export default function AdditionalInfoItem(props) {
       </div>
     </div>
   );
-}
+};
+
+export default AdditionalInfoItem;

--- a/src/client/js/components/partials/bridge/BridgeRouteBox.jsx
+++ b/src/client/js/components/partials/bridge/BridgeRouteBox.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// possible unused comp
 export default function BridgeRouteBox(props) {
   const info = props.info;
 

--- a/src/client/js/components/partials/bridge/RouteItemView.jsx
+++ b/src/client/js/components/partials/bridge/RouteItemView.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import TokenNetworkRouteBox from './TokenNetworkRouteBox';
-import BridgeRouteBox from './BridgeRouteBox';
 import SwapRouteBox from './SwapRouteBox';
 import AdditionalInfoItem from './AdditionalInfoItem';
 import DashedDivider from './DashedDivider';
 
-export default function RouteItemView(props) {
-  const data = props.data;
-
+const RouteItemView = ({ data }) => {
   return (
     <div className="bridge-route-item">
       {data.length > 0 &&
@@ -15,30 +12,21 @@ export default function RouteItemView(props) {
           switch (item.type) {
             case 'token-network':
               return (
-                <div
-                  key={index}
-                  className="is-flex is-flex-direction-row is-align-items-center"
-                >
+                <div key={index} className="is-flex is-flex-direction-row is-align-items-center">
                   <TokenNetworkRouteBox info={item} />
                   {data.length - 2 !== index && <DashedDivider />}
                 </div>
               );
             case 'swap':
               return (
-                <div
-                  key={index}
-                  className="is-flex is-flex-direction-row is-align-items-center"
-                >
+                <div key={index} className="is-flex is-flex-direction-row is-align-items-center">
                   <SwapRouteBox info={item} />
                   {data.length - 2 !== index && <DashedDivider />}
                 </div>
               );
             case 'bridge':
               return (
-                <div
-                  key={index}
-                  className="is-flex is-flex-direction-row is-align-items-center"
-                >
+                <div key={index} className="is-flex is-flex-direction-row is-align-items-center">
                   <SwapRouteBox info={item} />
                   {data.length - 2 !== index && <DashedDivider />}
                 </div>
@@ -51,4 +39,6 @@ export default function RouteItemView(props) {
         })}
     </div>
   );
-}
+};
+
+export default RouteItemView;

--- a/src/client/js/components/partials/bridge/SwapRouteBox.jsx
+++ b/src/client/js/components/partials/bridge/SwapRouteBox.jsx
@@ -1,35 +1,24 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-export default function SwapRouteBox(props) {
-  const info = props.info;
-
+const SwapRouteBox = ({ info }) => {
   return (
     <div className="swap-bridge-route-box">
       {info && (
         <>
           <div className="title-wrapper">
             <img
-              src={
-                info.type === 'swap'
-                  ? '/images/swap_box.svg'
-                  : '/images/bridge_box.svg'
-              }
+              src={info.type === 'swap' ? '/images/swap_box.svg' : '/images/bridge_box.svg'}
               alt={info.type === 'swap' ? 'swap-box' : 'bridge_box'}
             />
-            <div className="title">
-              {info.type === 'swap' ? 'Swap' : `${info.data.name} Bridge`}
-            </div>
+            <div className="title">{info.type === 'swap' ? 'Swap' : `${info.data.name} Bridge`}</div>
           </div>
           <div className="fee-wrapper">
-            <span className="text">
-              Fee:{' '}
-              {info.type === 'swap'
-                ? `$${info.data.fee}`
-                : `${info.data.fee}%`}
-            </span>
+            <span className="text">Fee: {info.type === 'swap' ? `$${info.data.fee}` : `${info.data.fee}%`}</span>
           </div>
         </>
       )}
     </div>
   );
-}
+};
+
+export default SwapRouteBox;

--- a/src/client/js/components/partials/bridge/TokenNetworkRouteBox.jsx
+++ b/src/client/js/components/partials/bridge/TokenNetworkRouteBox.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import TokenIconImg from '../TokenIconImg';
 
-export default function TokenNetworkRouteBox(props) {
-  const info = props.info;
+const TokenNetworkRouteBox = ({ info }) => {
+  const limitDecimalNumbers = (value) => Number.parseFloat(value).toFixed(6);
 
   return (
     <div className="token-network-route-box">
@@ -12,7 +12,7 @@ export default function TokenNetworkRouteBox(props) {
             <TokenIconImg size={16} mr={7} token={info.token} />
             <div>
               <div className="symbol">{info.token.symbol}</div>
-              <div className="amount">{info.amount}</div>
+              <div className="amount">{limitDecimalNumbers(info.amount)}</div>
             </div>
           </div>
           <div className="network-name" style={{ backgroundColor: info.network.color }}>
@@ -20,7 +20,8 @@ export default function TokenNetworkRouteBox(props) {
           </div>
         </div>
       )}
-
     </div>
   );
-}
+};
+
+export default TokenNetworkRouteBox;


### PR DESCRIPTION
Our bridges estimates are using a very long decimal count and as a side effect, it overflows the bridge UI box most of the time. 
﻿
﻿﻿﻿﻿I've noticed this after the new implementation for our estimates but not every time. One of our community testers reproduced it as well.
﻿﻿﻿﻿
﻿﻿﻿﻿
![image](https://user-images.githubusercontent.com/7452143/155025179-6197c50e-3c50-4876-a3fa-bc6e6687e154.png)