### PR TITLE
[Fix] decimal issue for get estimate within bridges routes

### DIFF
--- a/src/client/js/components/partials/bridge/BridgeWidget.jsx
+++ b/src/client/js/components/partials/bridge/BridgeWidget.jsx
@@ -38,33 +38,17 @@ export default class BridgeWidget extends Component {
       )[0]
     );
     */
+    const localStorageBridgeConfig = GlobalStateManager.bridge;
 
-    const network = TokenListManager.getCurrentNetworkConfig();
-    let mergeState = {};
-    const bridgeConfig = GlobalStateManager.getBridgeConfig();
-    const toChain = bridgeConfig?.toChain || this.CROSS_CHAIN_NETWORKS.find(
-      (v) => v.chainId !== network.chainId,
-    );
-    
-    const updatedConfig = {
-      fromChain: network,
-      toChain,
-      to: TokenListManager.findTokenById(bridgeConfig.to.symbol)  ||  TokenListManager.findTokenById(
-        toChain.supportedCrossChainTokens[0],
-        toChain,
-      ),
-      from: TokenListManager.findTokenById(bridgeConfig.from.symbol) || TokenListManager.findTokenById(network.supportedCrossChainTokens[0])
-    }
+    const { from, to, fromChain, toChain } = localStorageBridgeConfig;
 
-    GlobalStateManager.updateBridgeConfig(updatedConfig);
-
-    mergeState = _.extend(mergeState, {
-      ...updatedConfig
-    });
-
-    this.state = _.extend(mergeState, {
+    this.state = {
       fromAmount: undefined,
       toAmount: undefined,
+      from,
+      to,
+      fromChain,
+      toChain,
       availableBalance: undefined,
       swapDistribution: undefined,
       approveStatus: approvalState.UNKNOWN,
@@ -77,7 +61,7 @@ export default class BridgeWidget extends Component {
       transactionHash: '',
       crossChainTransactionId: false,
       refresh: Date.now(),
-    });
+    };
 
     this.subscribers = [];
     this.onSwapTokens = this.onSwapTokens.bind(this);
@@ -151,12 +135,13 @@ export default class BridgeWidget extends Component {
     const from = TokenListManager.findTokenById(
       network.supportedCrossChainTokens[0],
     )
+
     GlobalStateManager.updateBridgeConfig({
       toChain,
       fromChain,
       to,
       from,
-    })
+    });
     const defaultTo = TokenListManager.findTokenById(network.defaultPair.to);
     const defaultFrom = TokenListManager.findTokenById(network.defaultPair.from);
     GlobalStateManager.updateSwapConfig({
@@ -425,7 +410,6 @@ export default class BridgeWidget extends Component {
     if (this.state.searchTarget === 'from') {
       _s.fromAmount = SwapFn.validateEthValue(token, this.state.fromAmount);
     }
-
     GlobalStateManager.updateBridgeConfig({ ...bridgeConfig });
     this.setState(_s, () => {
       Metrics.track('swap-token-changed', {

--- a/src/client/js/utils/global.js
+++ b/src/client/js/utils/global.js
@@ -16,7 +16,7 @@ window.GlobalStateManager = {
     from: {},
     to: {},
     fromChain: '',
-    toChain: ''
+    toChain: '',
   },
 
   initialize: async function () {  
@@ -45,20 +45,18 @@ window.GlobalStateManager = {
       (v) => v.chainId !== network.chainId,
     );
 
-    const defaultBridgeConfig = {
-      from: TokenListManager.findTokenById(
-        network.supportedCrossChainTokens[0] || network.defaultPair.from
-      ),
-      to: TokenListManager.findTokenById(
-        toChain.supportedCrossChainTokens[0] || toChain.defaultPair.to,
-        toChain,
-      ),
-      fromChain: network.name,
-      toChain
-    };
-    const bridge = bridgeConfig ? bridgeConfig : defaultBridgeConfig;
+    const fromChain = crossChainNetworks.find((v) => {
+      return v.chainId === network.chainId;
+    });
 
-    this.updateBridgeConfig(bridge);
+    const defaultBridgeConfig = {
+      from: TokenListManager.findTokenById(network.supportedCrossChainTokens[0] || network.defaultPair.from),
+      to: TokenListManager.findTokenById(toChain.supportedCrossChainTokens[0] || toChain.defaultPair.to, toChain),
+      fromChain,
+      toChain,
+    };
+
+    this.updateBridgeConfig(defaultBridgeConfig);
   },
 
   updateSwapConfig: function (swap) {

--- a/src/client/js/utils/txBridgeManager.js
+++ b/src/client/js/utils/txBridgeManager.js
@@ -1,10 +1,7 @@
 import _ from 'underscore';
 import { BigNumber, constants, providers, Signer, utils } from 'ethers';
 import { getRandomBytes32 } from '@connext/nxtp-utils';
-import {
-  mappingToGenerateConnextArray,
-  mappingToGenerateArrayAnyBridge,
-} from './bridgeManagerMappings';
+import { mappingToGenerateConnextArray, mappingToGenerateArrayAnyBridge } from './bridgeManagerMappings';
 
 import HopUtils from './hop';
 import CBridgeUtils from './cbridge';
@@ -116,67 +113,6 @@ export default {
     }
 
     return bridges;
-  },
-
-  // TODO this is deprecated
-  async getEstimate(
-    sendingChainId,
-    sendingAssetId,
-    receivingChainId,
-    receivingAssetId,
-    amountBN,
-    receivingAddress,
-    sendingAssetDecimals,
-  ) {
-    const transactionId = getRandomBytes32();
-    const { bridgeOption } = Storage.swapSettings;
-
-    if (bridgeOption === 'cbridge') {
-      const estimate = await this.getBridgeInterface().getEstimate(
-        transactionId,
-        sendingChainId,
-        sendingAssetId,
-        receivingChainId,
-        receivingAssetId,
-        amountBN,
-        receivingAddress,
-        sendingAssetDecimals,
-      );
-
-      const { maxSlippage } = estimate;
-      this._queue[transactionId] = {
-        bridge: bridgeOption,
-        sendingChainId,
-        sendingAssetId,
-        receivingChainId,
-        receivingAssetId,
-        amountBN,
-        receivingAddress,
-        maxSlippage,
-      };
-
-      return estimate;
-    }
-
-    this._queue[transactionId] = {
-      bridge: bridgeOption,
-      sendingChainId,
-      sendingAssetId,
-      receivingChainId,
-      receivingAssetId,
-      amountBN,
-      receivingAddress,
-    };
-
-    return this.getBridgeInterface().getEstimate(
-      transactionId,
-      sendingChainId,
-      sendingAssetId,
-      receivingChainId,
-      receivingAssetId,
-      amountBN,
-      receivingAddress,
-    );
   },
 
   getAllEstimates(to, toChain, from, fromChain, amountBN, receivingAddress) {


### PR DESCRIPTION
Fix the bug that was pushed in the recent merges causing regression on the estimate within bridges, as a side-effect calculating the wrong decimals across the `toChain` for the bridge swaps.

i.e. in most of the cases, decimals for **bigInt** calculation uses `decimals: 18`, but for some networks like Polygon the stablecoins use `decimals: 06` returning the wrong value.


![image](https://user-images.githubusercontent.com/7452143/155531804-9422112f-498a-4ff9-a101-02832f64bed6.png)


Steps to reproduce the bug in development: 

1 - Clear the **localStorage**
2 - Hard refresh the page
3 - Access bridge tab
3 - `getEstimate` change the `to` chain (destination chain) to Polygon or any chain that use `decimals = 6`

✌️