### PR TITLE
Add abritrum optimism

### DIFF
--- a/public/config/main.config.json
+++ b/public/config/main.config.json
@@ -41,46 +41,83 @@
     ]
   },
   {
-    "enabled": false,
+    "enabled": true,
     "name": "Arbitrum",
     "aggregatorAddress": "0x689236A0C4A391FdD76dE5c6a759C7984166d166",
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png",
-    "bridgeURI": "https://wallet.matic.network/",
-    "tokenList": "/tokens/eth.list.json",
-    "chainId": "1287",
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/info/logo.png",
+    "bridgeURI": "https://bridge.arbitrum.io/",
+    "tokenList": "/tokens/42161.list.json",
+    "chainId": "42161",
     "nodeProviders": [
-      "https://api-matic.polkaswitch.com/3d041599a52783f163b2515d3ab10f900fc61c01/"
+      "https://arb-mainnet.g.alchemy.com/v2/kyKNf692Pn92sd3FTtg0pIBAnV5nuDUm"
     ],
-    "explorerBaseUrl": "https://polygonscan.com/tx/",
+    "explorerBaseUrl": "https://arbiscan.io/",
     "gasApi": "https://ethgasstation.info/json/ethgasAPI.json",
     "desiredParts": 3,
     "color": "#4E99E3",
     "abi": "oneSplitAbi",
     "chain": {
-      "chainId": "0x507",
-      "rpcUrls": ["https://rpc.testnet.moonbeam.network"],
-      "chainName": "Moonbeam Alphanet"
+      "chainId": "0xa4b1",
+      "rpcUrls": ["https://arb1.arbitrum.io/rpc"],
+      "chainName": "Arbitrum"
     },
     "defaultPair": {
-      "to": "0x806628fC9c801A5a7CcF8FfBC8a0ae3348C5F913",
-      "from": "0x798fA7Cf084129616B0108452aF3E1d5d1B32179"
+      "to": "USDT",
+      "from": "ETH"
     },
     "topTokens": [
       "ETH",
-      "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-      "0x514910771AF9Ca656af840dff83E8264EcF986CA",
-      "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
-      "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
-      "0xba100000625a3754423978a60c9317c58a424e3D",
-      "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
-      "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07"
+      "USDT",
+      "USDC",
+      "DAI"
     ],
     "coingecko": {
       "platform": "ethereum"
     },
-    "singleChainSupported": false,
+    "singleChainSupported": true,
     "crossChainSupported": false,
     "supportedCrossChainTokens": [
+     
+    ]
+  },
+  {
+    "enabled": true,
+    "name": "Optimism",
+    "aggregatorAddress": "0x689236A0C4A391FdD76dE5c6a759C7984166d166",
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/optimism/info/logo.png",
+    "bridgeURI": "https://gateway.optimism.io",
+    "tokenList": "/tokens/10.list.json",
+    "chainId": "10",
+    "nodeProviders": [
+      "https://opt-mainnet.g.alchemy.com/v2/rfsv3ngNyYWsCfQSnW60p0S58GXLdgnv"
+    ],
+    "explorerBaseUrl": "https://optimistic.etherscan.io/",
+    "gasApi": "https://ethgasstation.info/json/ethgasAPI.json",
+    "desiredParts": 3,
+    "color": "#4E99E3",
+    "abi": "oneSplitAbi",
+    "chain": {
+      "chainId": "0xa",
+      "rpcUrls": ["https://mainnet.optimism.io"],
+      "chainName": "Optimism"
+    },
+    "defaultPair": {
+      "to": "USDT",
+      "from": "ETH"
+    },
+    "topTokens": [
+      "ETH",
+      "USDT",
+      "USDC",
+      "DAI"
+    ],
+    "coingecko": {
+      "platform": "ethereum"
+    },
+    "singleChainSupported": true,
+    "crossChainSupported": false,
+    "supportedCrossChainTokens": [
+   
     ]
   },
   {

--- a/public/config/test.config.json
+++ b/public/config/test.config.json
@@ -42,7 +42,7 @@
   },
   {
     "enabled": true,
-    "name": "Arbitrum Testnet",
+    "name": "Arbitrum",
     "aggregatorAddress": "0x689236A0C4A391FdD76dE5c6a759C7984166d166",
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/info/logo.png",
     "bridgeURI": "https://bridge.arbitrum.io/",
@@ -82,7 +82,7 @@
   },
   {
     "enabled": true,
-    "name": "Optimism Testnet",
+    "name": "Optimism",
     "aggregatorAddress": "0x689236A0C4A391FdD76dE5c6a759C7984166d166",
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/optimism/info/logo.png",
     "bridgeURI": "https://gateway.optimism.io",

--- a/public/config/test.config.json
+++ b/public/config/test.config.json
@@ -20,8 +20,8 @@
       "chainName": "Ethereum Mainnet"
     },
     "defaultPair": {
-      "to": "ETH",
-      "from": "USDT"
+      "to": "USDT",
+      "from": "ETH"
     },
     "topTokens": [
       "ETH",
@@ -41,47 +41,83 @@
     ]
   },
   {
-    "enabled": false,
-    "name": "Arbitrum",
+    "enabled": true,
+    "name": "Arbitrum Testnet",
     "aggregatorAddress": "0x689236A0C4A391FdD76dE5c6a759C7984166d166",
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png",
-    "bridgeURI": "https://wallet.matic.network/",
-    "tokenList": "/tokens/eth.list.json",
-    "chainId": "1287",
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/info/logo.png",
+    "bridgeURI": "https://bridge.arbitrum.io/",
+    "tokenList": "/tokens/42161.list.json",
+    "chainId": "42161",
     "nodeProviders": [
-      "https://arb-mainnet.g.alchemy.com/v2/kyKNf692Pn92sd3FTtg0pIBAnV5nuDUm",
-      "https://api-matic.polkaswitch.com/3d041599a52783f163b2515d3ab10f900fc61c01/"
+      "https://arb-mainnet.g.alchemy.com/v2/kyKNf692Pn92sd3FTtg0pIBAnV5nuDUm"
     ],
-    "explorerBaseUrl": "https://polygonscan.com/tx/",
+    "explorerBaseUrl": "https://arbiscan.io/",
     "gasApi": "https://ethgasstation.info/json/ethgasAPI.json",
     "desiredParts": 3,
     "color": "#4E99E3",
     "abi": "oneSplitAbi",
     "chain": {
-      "chainId": "0x507",
-      "rpcUrls": ["https://rpc.testnet.moonbeam.network"],
-      "chainName": "Moonbeam Alphanet"
+      "chainId": "0xa4b1",
+      "rpcUrls": ["https://arb1.arbitrum.io/rpc"],
+      "chainName": "Arbitrum"
     },
     "defaultPair": {
-      "to": "0x806628fC9c801A5a7CcF8FfBC8a0ae3348C5F913",
-      "from": "0x798fA7Cf084129616B0108452aF3E1d5d1B32179"
+      "to": "USDT",
+      "from": "ETH"
     },
     "topTokens": [
       "ETH",
-      "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-      "0x514910771AF9Ca656af840dff83E8264EcF986CA",
-      "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
-      "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
-      "0xba100000625a3754423978a60c9317c58a424e3D",
-      "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
-      "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07"
+      "USDT",
+      "USDC",
+      "DAI"
     ],
     "coingecko": {
       "platform": "ethereum"
     },
-    "singleChainSupported": false,
+    "singleChainSupported": true,
     "crossChainSupported": false,
     "supportedCrossChainTokens": [
+     
+    ]
+  },
+  {
+    "enabled": true,
+    "name": "Optimism Testnet",
+    "aggregatorAddress": "0x689236A0C4A391FdD76dE5c6a759C7984166d166",
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/optimism/info/logo.png",
+    "bridgeURI": "https://gateway.optimism.io",
+    "tokenList": "/tokens/10.list.json",
+    "chainId": "10",
+    "nodeProviders": [
+      "https://opt-mainnet.g.alchemy.com/v2/rfsv3ngNyYWsCfQSnW60p0S58GXLdgnv"
+    ],
+    "explorerBaseUrl": "https://optimistic.etherscan.io/",
+    "gasApi": "https://ethgasstation.info/json/ethgasAPI.json",
+    "desiredParts": 3,
+    "color": "#4E99E3",
+    "abi": "oneSplitAbi",
+    "chain": {
+      "chainId": "0xa",
+      "rpcUrls": ["https://mainnet.optimism.io"],
+      "chainName": "Optimism"
+    },
+    "defaultPair": {
+      "to": "USDT",
+      "from": "ETH"
+    },
+    "topTokens": [
+      "ETH",
+      "USDT",
+      "USDC",
+      "DAI"
+    ],
+    "coingecko": {
+      "platform": "ethereum"
+    },
+    "singleChainSupported": true,
+    "crossChainSupported": false,
+    "supportedCrossChainTokens": [
+   
     ]
   },
   {

--- a/public/tokens/10.list.json
+++ b/public/tokens/10.list.json
@@ -1,0 +1,107 @@
+[
+    {
+        "symbol": "ETH",
+        "name": "Ethereum",
+        "decimals": 18,
+        "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "logoURI": "https://tokens.1inch.io/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png",
+        "chainId": 10,
+        "native": true
+    },
+    {
+        "symbol": "WETH",
+        "name": "Wrapped Ether",
+        "address": "0x4200000000000000000000000000000000000006",
+        "decimals": 18,
+        "logoURI": "https://tokens.1inch.io/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "chainId": 10
+    },
+    {
+        "symbol": "SNX",
+        "name": "Synthetix",
+        "decimals": 18,
+        "logoURI": "https://ethereum-optimism.github.io/logos/SNX.svg",
+        "address": "0x8700daec35af8ff88c16bdf0418774cb3d7599b4",
+        "chainId": 10
+    },
+    {
+        "symbol": "DAI",
+        "name": "Dai stable coin",
+        "decimals": 18,
+        "logoURI": "https://cryptologos.cc/logos/multi-collateral-dai-dai-logo.svg?v=010",
+        "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+        "chainId": 10
+    },
+    {
+        "symbol": "USDT",
+        "name": "Tether USD",
+        "decimals": 6,
+        "logoURI": "https://tokens.1inch.io/0x94b008aa00579c1307b0ef2c499ad98a8ce58e58.png",
+        "address": "0x94b008aa00579c1307b0ef2c499ad98a8ce58e58",
+        "chainId": 10
+    },
+    {
+        "symbol": "WBTC",
+        "name": "Wrapped Bitcoin",
+        "decimals": 8,
+        "logoURI": "https://ethereum-optimism.github.io/logos/WBTC.svg",
+        "address": "0x68f180fcce6836688e9084f035309e29bf0a2095",
+        "chainId": 10
+    },
+    {
+        "symbol": "LINK",
+        "name": "Chainlink",
+        "decimals": 18,
+        "logoURI": "https://tokens.1inch.io/0x350a791bfc2c21f9ed5d10980dad2e2638ffa7f6.png",
+        "address": "0x350a791bfc2c21f9ed5d10980dad2e2638ffa7f6",
+        "chainId": 10
+    },
+    {
+        "symbol": "USDC",
+        "name": "USD Coin",
+        "decimals": 6,
+        "logoURI": "https://tokens.1inch.io/0x7f5c764cbc14f9669b88837ca1490cca17c31607.png",
+        "address": "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+        "chainId": 10
+    },
+    {
+        "symbol": "sUSD",
+        "name": "Synth sUSD",
+        "decimals": 18,
+        "logoURI": "https://tokens.1inch.io/0x57ab1ec28d129707052df4df418d58a2d46d5f51.png",
+        "address": "0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9",
+        "chainId": 10
+    },
+    {
+        "symbol": "THALES",
+        "name": "Optimistic Thales Token",
+        "decimals": 18,
+        "logoURI": "https://tokens.1inch.io/0x217d47011b23bb961eb6d93ca9945b7501a5bb11.png",
+        "address": "0x217d47011b23bb961eb6d93ca9945b7501a5bb11",
+        "chainId": 10
+    },
+    {
+        "symbol": "AELIN",
+        "name": "Aelin Token",
+        "decimals": 18,
+        "address": "0x61baadcf22d2565b0f471b291c475db5555e0b76",
+        "logoURI": "https://tokens.1inch.io/0x61baadcf22d2565b0f471b291c475db5555e0b76.png",
+        "chainId": 10
+    },
+    {
+        "symbol": "RAI",
+        "name": "Rai Reflex Index",
+        "decimals": 18,
+        "address": "0x7fb688ccf682d58f86d7e38e03f9d22e7705448b",
+        "logoURI": "https://tokens.1inch.io/0x7fb688ccf682d58f86d7e38e03f9d22e7705448b.png",
+        "chainId": 10
+    },
+    {
+        "symbol": "LYRA",
+        "name": "Lyra Token",
+        "decimals": 18,
+        "address": "0x50c5725949a6f0c72e6c4a641f24049a917db0cb",
+        "logoURI": "https://tokens.1inch.io/0x50c5725949a6f0c72e6c4a641f24049a917db0cb.png",
+        "chainId": 10
+    }
+]

--- a/public/tokens/42161.list.json
+++ b/public/tokens/42161.list.json
@@ -5,7 +5,7 @@
         "decimals": 18,
         "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         "logoURI": "https://tokens.1inch.io/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png",
-        "chainId":42161,
+        "chainId": 42161,
         "native": true
     },
     {
@@ -14,7 +14,7 @@
         "decimals": 18,
         "logoURI": "https://zapper.fi/images/ALCH-icon.png",
         "address": "0x0e15258734300290a651fdbae8deb039a8e7a2fa",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "BADGER",
@@ -22,7 +22,7 @@
         "decimals": 18,
         "address": "0xbfa641051ba0a0ad1b0acf549a89536a0d76472e",
         "logoURI": "https://tokens.1inch.io/0x3472a5a71965499acd81997a54bba8d852c6e53d.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "BAL",
@@ -30,7 +30,7 @@
         "decimals": 18,
         "address": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
         "logoURI": "https://tokens.1inch.io/0xba100000625a3754423978a60c9317c58a424e3d.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "BOND",
@@ -38,7 +38,7 @@
         "decimals": 18,
         "address": "0x0d81e50bc677fa67341c44d7eaa9228dee64a4e1",
         "logoURI": "https://tokens.1inch.io/0x0391d2021f89dc339f60fff84546ea23e337750f.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "CAP",
@@ -46,7 +46,7 @@
         "decimals": 18,
         "address": "0x031d35296154279dc1984dcd93e392b1f946737b",
         "logoURI": "https://tokens.1inch.io/0x43044f861ec040db59a7e324c40507addb673142.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "CELR",
@@ -54,7 +54,7 @@
         "decimals": 18,
         "logoURI": "https://zapper.fi/images/CELR-icon.png",
         "address": "0x3a8b787f78d775aecfeea15706d4221b40f345ab",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "COMP",
@@ -62,7 +62,7 @@
         "decimals": 18,
         "address": "0x354a6da3fcde098f8389cad84b0182725c6c91de",
         "logoURI": "https://tokens.1inch.io/0xc00e94cb662c3520282e6f5717214004a7f26888.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "CREAM",
@@ -70,7 +70,7 @@
         "decimals": 18,
         "address": "0xf4d48ce3ee1ac3651998971541badbb9a14d7234",
         "logoURI": "https://tokens.1inch.io/0x2ba592f78db6436527729929aaf6c908497cb200.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "CRV",
@@ -78,7 +78,7 @@
         "decimals": 18,
         "address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
         "logoURI": "https://tokens.1inch.io/0xd533a949740bb3306d119cc777fa900ba034cd52.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "DEGEN",
@@ -86,7 +86,7 @@
         "decimals": 18,
         "address": "0xae6e3540e97b0b9ea8797b157b510e133afb6282",
         "logoURI": "https://tokens.1inch.io/0x126c121f99e1e211df2e5f8de2d96fa36647c855.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "DHT",
@@ -94,7 +94,7 @@
         "decimals": 18,
         "address": "0x8038f3c971414fd1fc220ba727f2d4a0fc98cb65",
         "logoURI": "https://tokens.1inch.io/0xca1207647ff814039530d7d35df0e1dd2e91fa84.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "DODO",
@@ -102,7 +102,7 @@
         "decimals": 18,
         "address": "0x69eb4fa4a2fbd498c257c57ea8b7655a2559a581",
         "logoURI": "https://tokens.1inch.io/0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "DXD",
@@ -110,14 +110,14 @@
         "decimals": 18,
         "address": "0xc3ae0333f0f34aa734d5493276223d95b8f9cb37",
         "logoURI": "https://tokens.1inch.io/0xa1d65e8fb6e87b60feccbc582f7f97804b725521.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "EUX",
         "name": "dForce EUR",
         "decimals": 18,
         "address": "0x969131d8ddc06c2be11a13e6e7facf22cf57d95e",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "FUSE",
@@ -125,7 +125,7 @@
         "decimals": 18,
         "address": "0xbdef0e9ef12e689f366fe494a7a7d0dad25d9286",
         "logoURI": "https://tokens.1inch.io/0x970b9bb2c0444f5e81e9d0efb84c8ccdcdcaf84d.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "GMX",
@@ -133,7 +133,7 @@
         "decimals": 18,
         "address": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
         "logoURI": "https://tokens.1inch.io/0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "GNO",
@@ -141,7 +141,7 @@
         "decimals": 18,
         "address": "0xa0b862f60edef4452f25b4160f177db44deb6cf1",
         "logoURI": "https://tokens.1inch.io/0x6810e776880c02933d47db1b9fc05908e5386b96.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "GRT",
@@ -149,7 +149,7 @@
         "decimals": 18,
         "address": "0x23a941036ae778ac51ab04cea08ed6e2fe103614",
         "logoURI": "https://tokens.1inch.io/0xc944e90c64b2c07662a292be6244bdf05cda44a7.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "KUN",
@@ -164,7 +164,7 @@
         "decimals": 18,
         "address": "0x3cd1833ce959e087d0ef0cb45ed06bffe60f23ba",
         "logoURI": "https://tokens.1inch.io/0x9d986a3f147212327dd658f712d5264a73a1fdb0.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "LINK",
@@ -172,7 +172,7 @@
         "decimals": 18,
         "address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
         "logoURI": "https://tokens.1inch.io/0x514910771af9ca656af840dff83e8264ecf986ca.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "LRC",
@@ -180,7 +180,7 @@
         "decimals": 18,
         "address": "0x46d0ce7de6247b0a95f67b43b589b4041bae7fbe",
         "logoURI": "https://tokens.1inch.io/0xbbbbca6a901c926f240b89eacb641d8aec7aeafd.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "MATH",
@@ -188,7 +188,7 @@
         "decimals": 18,
         "address": "0x99f40b01ba9c469193b360f72740e416b17ac332",
         "logoURI": "https://tokens.1inch.io/0x08d967bb0134f2d07f7cfb6e246680c53927dd30.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "MCB",
@@ -196,7 +196,7 @@
         "decimals": 18,
         "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
         "logoURI": "https://tokens.1inch.io/0x4e352cf164e64adcbad318c3a1e222e9eba4ce42.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "MKR",
@@ -204,7 +204,7 @@
         "decimals": 18,
         "address": "0x2e9a6df78e42a30712c10a9dc4b1c8656f8f2879",
         "logoURI": "https://tokens.1inch.io/0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "MTA",
@@ -212,7 +212,7 @@
         "decimals": 18,
         "address": "0x5298ee77a8f9e226898403ebac33e68a62f770a0",
         "logoURI": "https://tokens.1inch.io/0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "NDX",
@@ -220,7 +220,7 @@
         "decimals": 18,
         "address": "0xb965029343d55189c25a7f3e0c9394dc0f5d41b1",
         "logoURI": "https://tokens.1inch.io/0x86772b1409b61c639eaac9ba0acfbb6e238e5f83.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "OVR",
@@ -228,14 +228,14 @@
         "decimals": 18,
         "address": "0x55704a0e9e2eb59e176c5b69655dbd3dcdcfc0f0",
         "logoURI": "https://tokens.1inch.io/0x21bfbda47a0b4b5b1248c767ee49f7caa9b23697.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "PL2",
         "name": "Plenny",
         "decimals": 18,
         "address": "0x3642c0680329ae3e103e2b5ab29ddfed4d43cbe5",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "PREMIA",
@@ -243,7 +243,7 @@
         "decimals": 18,
         "address": "0x51fc0f6660482ea73330e414efd7808811a57fa2",
         "logoURI": "https://tokens.1inch.io/0x6399c842dd2be3de30bf99bc7d1bbf6fa3650e70.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "RGT",
@@ -251,7 +251,7 @@
         "decimals": 18,
         "address": "0xef888bca6ab6b1d26dbec977c455388ecd794794",
         "logoURI": "https://tokens.1inch.io/0xd291e7a03283640fdc51b121ac401383a46cc623.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "SDT",
@@ -259,7 +259,7 @@
         "decimals": 18,
         "address": "0x7ba4a00d54a07461d9db2aef539e91409943adc9",
         "logoURI": "https://tokens.1inch.io/0x73968b9a57c6e53d41345fd57a6e6ae27d6cdb2f.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "SUSHI",
@@ -267,14 +267,14 @@
         "decimals": 18,
         "address": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
         "logoURI": "https://tokens.1inch.io/0x6b3595068778dd592e39a122f4f5a5cf09c90fe2.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "SWPR",
         "name": "Swapr",
         "decimals": 18,
         "address": "0xde903e2712288a1da82942dddf2c20529565ac30",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "UNI",
@@ -282,7 +282,7 @@
         "decimals": 18,
         "address": "0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0",
         "logoURI": "https://tokens.1inch.io/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "USDC",
@@ -290,7 +290,7 @@
         "decimals": 6,
         "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
         "logoURI": "https://tokens.1inch.io/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "USDT",
@@ -298,14 +298,14 @@
         "decimals": 6,
         "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
         "logoURI": "https://tokens.1inch.io/0xdac17f958d2ee523a2206206994597c13d831ec7.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "USX",
         "name": "dForce USD",
         "decimals": 18,
         "address": "0xcd14c3a2ba27819b352aae73414a26e2b366dc50",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "VISR",
@@ -313,7 +313,7 @@
         "decimals": 18,
         "address": "0x995c235521820f2637303ca1970c7c044583df44",
         "logoURI": "https://tokens.1inch.io/0xf938424f7210f31df2aee3011291b658f872e91e.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "WBTC",
@@ -321,14 +321,14 @@
         "decimals": 8,
         "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
         "logoURI": "https://tokens.1inch.io/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "WCHI",
         "name": "Wrapped CHI",
         "decimals": 8,
         "address": "0xa64ecce74f8cdb7a940766b71f1b108bac69851a",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "WETH",
@@ -336,7 +336,7 @@
         "decimals": 18,
         "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
         "logoURI": "https://tokens.1inch.io/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "WOO",
@@ -344,7 +344,7 @@
         "decimals": 18,
         "address": "0xcafcd85d8ca7ad1e1c6f82f651fa15e33aefd07b",
         "logoURI": "https://tokens.1inch.io/0x4691937a7508860f876c9c0a2a617e7d9e945d4b.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "YFI",
@@ -352,7 +352,7 @@
         "decimals": 18,
         "address": "0x82e3a8f066a6989666b031d916c43672085b1582",
         "logoURI": "https://tokens.1inch.io/0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "ZIPT",
@@ -360,7 +360,7 @@
         "decimals": 18,
         "address": "0x0f61b24272af65eacf6adfe507028957698e032f",
         "logoURI": "https://tokens.1inch.io/0xedd7c94fd7b4971b916d15067bc454b9e1bad980.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "DAI",
@@ -368,7 +368,7 @@
         "decimals": 18,
         "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
         "logoURI": "https://tokens.1inch.io/0x6b175474e89094c44da98b954eedeac495271d0f.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "MIM",
@@ -377,7 +377,7 @@
         "eip2612": true,
         "address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
         "logoURI": "https://tokens.1inch.io/0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "SPELL",
@@ -385,7 +385,7 @@
         "decimals": 18,
         "address": "0x3e6648c5a70a150a88bce65f4ad4d506fe15d2af",
         "logoURI": "https://tokens.1inch.io/0x3e6648c5a70a150a88bce65f4ad4d506fe15d2af.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "wsOHM",
@@ -393,7 +393,7 @@
         "decimals": 18,
         "address": "0x739ca6d71365a08f584c8fc4e1029045fa8abc4b",
         "logoURI": "https://tokens.1inch.io/0x739ca6d71365a08f584c8fc4e1029045fa8abc4b.png",
-        "chainId":42161
+        "chainId": 42161
     },
     {
         "symbol": "deUSDC",
@@ -401,6 +401,6 @@
         "decimals": 6,
         "address": "0x1ddcaa4ed761428ae348befc6718bcb12e63bfaa",
         "logoURI": "https://tokens.1inch.io/0x1ddcaa4ed761428ae348befc6718bcb12e63bfaa.png",
-        "chainId":42161
+        "chainId": 42161
     }
 ]

--- a/public/tokens/42161.list.json
+++ b/public/tokens/42161.list.json
@@ -1,0 +1,406 @@
+[
+    {
+        "symbol": "ETH",
+        "name": "Ethereum",
+        "decimals": 18,
+        "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        "logoURI": "https://tokens.1inch.io/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png",
+        "chainId":42161,
+        "native": true
+    },
+    {
+        "symbol": "ALCH",
+        "name": "Alchemy",
+        "decimals": 18,
+        "logoURI": "https://zapper.fi/images/ALCH-icon.png",
+        "address": "0x0e15258734300290a651fdbae8deb039a8e7a2fa",
+        "chainId":42161
+    },
+    {
+        "symbol": "BADGER",
+        "name": "Badger",
+        "decimals": 18,
+        "address": "0xbfa641051ba0a0ad1b0acf549a89536a0d76472e",
+        "logoURI": "https://tokens.1inch.io/0x3472a5a71965499acd81997a54bba8d852c6e53d.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "BAL",
+        "name": "Balancer",
+        "decimals": 18,
+        "address": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+        "logoURI": "https://tokens.1inch.io/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "BOND",
+        "name": "BarnBridge Governance Token",
+        "decimals": 18,
+        "address": "0x0d81e50bc677fa67341c44d7eaa9228dee64a4e1",
+        "logoURI": "https://tokens.1inch.io/0x0391d2021f89dc339f60fff84546ea23e337750f.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "CAP",
+        "name": "Cap",
+        "decimals": 18,
+        "address": "0x031d35296154279dc1984dcd93e392b1f946737b",
+        "logoURI": "https://tokens.1inch.io/0x43044f861ec040db59a7e324c40507addb673142.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "CELR",
+        "name": "CelerToken",
+        "decimals": 18,
+        "logoURI": "https://zapper.fi/images/CELR-icon.png",
+        "address": "0x3a8b787f78d775aecfeea15706d4221b40f345ab",
+        "chainId":42161
+    },
+    {
+        "symbol": "COMP",
+        "name": "Compound",
+        "decimals": 18,
+        "address": "0x354a6da3fcde098f8389cad84b0182725c6c91de",
+        "logoURI": "https://tokens.1inch.io/0xc00e94cb662c3520282e6f5717214004a7f26888.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "CREAM",
+        "name": "Cream",
+        "decimals": 18,
+        "address": "0xf4d48ce3ee1ac3651998971541badbb9a14d7234",
+        "logoURI": "https://tokens.1inch.io/0x2ba592f78db6436527729929aaf6c908497cb200.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "CRV",
+        "name": "Curve DAO Token",
+        "decimals": 18,
+        "address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
+        "logoURI": "https://tokens.1inch.io/0xd533a949740bb3306d119cc777fa900ba034cd52.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "DEGEN",
+        "name": "DEGEN Index",
+        "decimals": 18,
+        "address": "0xae6e3540e97b0b9ea8797b157b510e133afb6282",
+        "logoURI": "https://tokens.1inch.io/0x126c121f99e1e211df2e5f8de2d96fa36647c855.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "DHT",
+        "name": "dHedge DAO Token",
+        "decimals": 18,
+        "address": "0x8038f3c971414fd1fc220ba727f2d4a0fc98cb65",
+        "logoURI": "https://tokens.1inch.io/0xca1207647ff814039530d7d35df0e1dd2e91fa84.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "DODO",
+        "name": "DODO bird",
+        "decimals": 18,
+        "address": "0x69eb4fa4a2fbd498c257c57ea8b7655a2559a581",
+        "logoURI": "https://tokens.1inch.io/0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "DXD",
+        "name": "DXdao",
+        "decimals": 18,
+        "address": "0xc3ae0333f0f34aa734d5493276223d95b8f9cb37",
+        "logoURI": "https://tokens.1inch.io/0xa1d65e8fb6e87b60feccbc582f7f97804b725521.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "EUX",
+        "name": "dForce EUR",
+        "decimals": 18,
+        "address": "0x969131d8ddc06c2be11a13e6e7facf22cf57d95e",
+        "chainId":42161
+    },
+    {
+        "symbol": "FUSE",
+        "name": "Fuse Token",
+        "decimals": 18,
+        "address": "0xbdef0e9ef12e689f366fe494a7a7d0dad25d9286",
+        "logoURI": "https://tokens.1inch.io/0x970b9bb2c0444f5e81e9d0efb84c8ccdcdcaf84d.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "GMX",
+        "name": "GMX",
+        "decimals": 18,
+        "address": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
+        "logoURI": "https://tokens.1inch.io/0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "GNO",
+        "name": "Gnosis Token",
+        "decimals": 18,
+        "address": "0xa0b862f60edef4452f25b4160f177db44deb6cf1",
+        "logoURI": "https://tokens.1inch.io/0x6810e776880c02933d47db1b9fc05908e5386b96.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "GRT",
+        "name": "Graph Token",
+        "decimals": 18,
+        "address": "0x23a941036ae778ac51ab04cea08ed6e2fe103614",
+        "logoURI": "https://tokens.1inch.io/0xc944e90c64b2c07662a292be6244bdf05cda44a7.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "KUN",
+        "name": "QIAN governance token",
+        "decimals": 18,
+        "logoURI": "https://zapper.fi/images/KUN-icon.png",
+        "address": "0x04cb2d263a7489f02d813eaab9ba1bb8466347f2"
+    },
+    {
+        "symbol": "LAND",
+        "name": "Land",
+        "decimals": 18,
+        "address": "0x3cd1833ce959e087d0ef0cb45ed06bffe60f23ba",
+        "logoURI": "https://tokens.1inch.io/0x9d986a3f147212327dd658f712d5264a73a1fdb0.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "LINK",
+        "name": "ChainLink Token",
+        "decimals": 18,
+        "address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
+        "logoURI": "https://tokens.1inch.io/0x514910771af9ca656af840dff83e8264ecf986ca.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "LRC",
+        "name": "LoopringCoin V2",
+        "decimals": 18,
+        "address": "0x46d0ce7de6247b0a95f67b43b589b4041bae7fbe",
+        "logoURI": "https://tokens.1inch.io/0xbbbbca6a901c926f240b89eacb641d8aec7aeafd.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "MATH",
+        "name": "MATH Token",
+        "decimals": 18,
+        "address": "0x99f40b01ba9c469193b360f72740e416b17ac332",
+        "logoURI": "https://tokens.1inch.io/0x08d967bb0134f2d07f7cfb6e246680c53927dd30.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "MCB",
+        "name": "MCDEX Token",
+        "decimals": 18,
+        "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+        "logoURI": "https://tokens.1inch.io/0x4e352cf164e64adcbad318c3a1e222e9eba4ce42.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "MKR",
+        "name": "Maker",
+        "decimals": 18,
+        "address": "0x2e9a6df78e42a30712c10a9dc4b1c8656f8f2879",
+        "logoURI": "https://tokens.1inch.io/0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "MTA",
+        "name": "Meta",
+        "decimals": 18,
+        "address": "0x5298ee77a8f9e226898403ebac33e68a62f770a0",
+        "logoURI": "https://tokens.1inch.io/0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "NDX",
+        "name": "Indexed",
+        "decimals": 18,
+        "address": "0xb965029343d55189c25a7f3e0c9394dc0f5d41b1",
+        "logoURI": "https://tokens.1inch.io/0x86772b1409b61c639eaac9ba0acfbb6e238e5f83.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "OVR",
+        "name": "OVR",
+        "decimals": 18,
+        "address": "0x55704a0e9e2eb59e176c5b69655dbd3dcdcfc0f0",
+        "logoURI": "https://tokens.1inch.io/0x21bfbda47a0b4b5b1248c767ee49f7caa9b23697.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "PL2",
+        "name": "Plenny",
+        "decimals": 18,
+        "address": "0x3642c0680329ae3e103e2b5ab29ddfed4d43cbe5",
+        "chainId":42161
+    },
+    {
+        "symbol": "PREMIA",
+        "name": "Premia",
+        "decimals": 18,
+        "address": "0x51fc0f6660482ea73330e414efd7808811a57fa2",
+        "logoURI": "https://tokens.1inch.io/0x6399c842dd2be3de30bf99bc7d1bbf6fa3650e70.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "RGT",
+        "name": "Rari Governance Token",
+        "decimals": 18,
+        "address": "0xef888bca6ab6b1d26dbec977c455388ecd794794",
+        "logoURI": "https://tokens.1inch.io/0xd291e7a03283640fdc51b121ac401383a46cc623.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "SDT",
+        "name": "Stake DAO Token",
+        "decimals": 18,
+        "address": "0x7ba4a00d54a07461d9db2aef539e91409943adc9",
+        "logoURI": "https://tokens.1inch.io/0x73968b9a57c6e53d41345fd57a6e6ae27d6cdb2f.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "SUSHI",
+        "name": "SushiToken",
+        "decimals": 18,
+        "address": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
+        "logoURI": "https://tokens.1inch.io/0x6b3595068778dd592e39a122f4f5a5cf09c90fe2.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "SWPR",
+        "name": "Swapr",
+        "decimals": 18,
+        "address": "0xde903e2712288a1da82942dddf2c20529565ac30",
+        "chainId":42161
+    },
+    {
+        "symbol": "UNI",
+        "name": "Uniswap",
+        "decimals": 18,
+        "address": "0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0",
+        "logoURI": "https://tokens.1inch.io/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "USDC",
+        "name": "USD Coin Arb1",
+        "decimals": 6,
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "logoURI": "https://tokens.1inch.io/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "USDT",
+        "name": "Tether USD",
+        "decimals": 6,
+        "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+        "logoURI": "https://tokens.1inch.io/0xdac17f958d2ee523a2206206994597c13d831ec7.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "USX",
+        "name": "dForce USD",
+        "decimals": 18,
+        "address": "0xcd14c3a2ba27819b352aae73414a26e2b366dc50",
+        "chainId":42161
+    },
+    {
+        "symbol": "VISR",
+        "name": "VISOR",
+        "decimals": 18,
+        "address": "0x995c235521820f2637303ca1970c7c044583df44",
+        "logoURI": "https://tokens.1inch.io/0xf938424f7210f31df2aee3011291b658f872e91e.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "WBTC",
+        "name": "Wrapped BTC",
+        "decimals": 8,
+        "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+        "logoURI": "https://tokens.1inch.io/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "WCHI",
+        "name": "Wrapped CHI",
+        "decimals": 8,
+        "address": "0xa64ecce74f8cdb7a940766b71f1b108bac69851a",
+        "chainId":42161
+    },
+    {
+        "symbol": "WETH",
+        "name": "Wrapped Ether",
+        "decimals": 18,
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "logoURI": "https://tokens.1inch.io/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "WOO",
+        "name": "Wootrade Network",
+        "decimals": 18,
+        "address": "0xcafcd85d8ca7ad1e1c6f82f651fa15e33aefd07b",
+        "logoURI": "https://tokens.1inch.io/0x4691937a7508860f876c9c0a2a617e7d9e945d4b.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "YFI",
+        "name": "yearn.finance",
+        "decimals": 18,
+        "address": "0x82e3a8f066a6989666b031d916c43672085b1582",
+        "logoURI": "https://tokens.1inch.io/0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "ZIPT",
+        "name": "Zippie",
+        "decimals": 18,
+        "address": "0x0f61b24272af65eacf6adfe507028957698e032f",
+        "logoURI": "https://tokens.1inch.io/0xedd7c94fd7b4971b916d15067bc454b9e1bad980.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "DAI",
+        "name": "Dai Stablecoin",
+        "decimals": 18,
+        "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+        "logoURI": "https://tokens.1inch.io/0x6b175474e89094c44da98b954eedeac495271d0f.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "MIM",
+        "name": "Magic Internet Money",
+        "decimals": 18,
+        "eip2612": true,
+        "address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
+        "logoURI": "https://tokens.1inch.io/0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "SPELL",
+        "name": "Spell Token",
+        "decimals": 18,
+        "address": "0x3e6648c5a70a150a88bce65f4ad4d506fe15d2af",
+        "logoURI": "https://tokens.1inch.io/0x3e6648c5a70a150a88bce65f4ad4d506fe15d2af.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "wsOHM",
+        "name": "Wrapped sOHM",
+        "decimals": 18,
+        "address": "0x739ca6d71365a08f584c8fc4e1029045fa8abc4b",
+        "logoURI": "https://tokens.1inch.io/0x739ca6d71365a08f584c8fc4e1029045fa8abc4b.png",
+        "chainId":42161
+    },
+    {
+        "symbol": "deUSDC",
+        "name": "deBridge USD Coin",
+        "decimals": 6,
+        "address": "0x1ddcaa4ed761428ae348befc6718bcb12e63bfaa",
+        "logoURI": "https://tokens.1inch.io/0x1ddcaa4ed761428ae348befc6718bcb12e63bfaa.png",
+        "chainId":42161
+    }
+]

--- a/src/client/js/utils/swapFn.js
+++ b/src/client/js/utils/swapFn.js
@@ -268,7 +268,7 @@ window.SwapFn = {
       }
     }
 
-    if (chainId === '1') {
+    if (chainId === '1' || chainId === '42161' || chainId === '10') {
       const { destAmount, route, distribution } = (await PathFinder.getQuote(fromToken.symbol, toToken.symbol, amount, chainId)) || {};
       if (destAmount) {
         const returnAmount = new BN(destAmount).times(10 ** toToken.decimals).toFixed(0);
@@ -315,7 +315,6 @@ window.SwapFn = {
     console.log(`Calling SWAP() with ${fromToken.symbol} to ${toToken.symbol} of ${amountBN.toString()}`);
     const { chainId, contract, recipient } = this.getContract();
     const pathRoute = localStorage.getItem('route');
-
     if (['oneinch', 'paraswap'].includes(pathRoute)) {
       const originAmount = new BN(amountBN.toString()).dividedBy(10 ** fromToken.decimals);
       return PathFinder.getSwap(fromToken.symbol, toToken.symbol, originAmount, pathRoute, chainId);


### PR DESCRIPTION
Paraswap does not support Abritrum and optimism so it will fired a 500 error code.   I've fixed in the PR https://github.com/polkaswitch/PathFinder/pull/12

Tested by using local api.  

Noted: aggregatorAddress in the configuration file has not updated yet. 